### PR TITLE
Changed LogRecord for methods to include instance information into TR…

### DIFF
--- a/autologging.py
+++ b/autologging.py
@@ -1191,7 +1191,7 @@ class _FunctionTracingProxy(object):
             "CALL *%r **%r",     # msg
             (args, keywords),    # args
             None,                # exc_info
-            func=function.__name__))
+            func=repr(function)))
 
         value = function(*args, **keywords)
 
@@ -1203,7 +1203,7 @@ class _FunctionTracingProxy(object):
             "RETURN %r",         # msg
             (value,),            # args
             None,                # exc_info
-            func=function.__name__))
+            func=repr(function)))
 
         return (_GeneratorIteratorTracingProxy(function, value, self._logger)
                 if isgenerator(value) else value)


### PR DESCRIPTION
The proposed change is an example how to include information about the instance whose method is called, into the tracer.

Background: the original implementation shows only the class and the method name, thus the same method of **two distinct instances** of the same class called with the same arguments will generate the **same** TRACE record. Distinguishing the traces from different instances will help to improve the class behaviur.

Status of the proposal: it was tested on a trivial class by decorating it with ``@traced``. The use of the decorator on other callables, i.e. unbound functions was not tested. The impact onto performace was not assessed. 